### PR TITLE
Fix false positives in Definitions

### DIFF
--- a/IBMQuantum/Definitions.yml
+++ b/IBMQuantum/Definitions.yml
@@ -33,6 +33,7 @@ exceptions:
   - JSX
   - LESS
   - LLDB
+  - NBQA
   - NET
   - NOTE
   - NVDA

--- a/IBMQuantum/Definitions.yml
+++ b/IBMQuantum/Definitions.yml
@@ -27,6 +27,7 @@ exceptions:
   - HTML
   - HTTP
   - HTTPS
+  - IBM
   - IDE
   - JAR
   - JSON


### PR DESCRIPTION
- Modifies `IBMQuantum.Definitions` to ignore 'NBQA'.
  Fixes #5, see issue for context.
- Adds 'IBM' as a recognized acronym.
