### PR TITLE
Refine rules

### DIFF
--- a/IBMQuantum/Headings.yml
+++ b/IBMQuantum/Headings.yml
@@ -1,10 +1,19 @@
 extends: capitalization
 message: "'%s' should use sentence-style capitalization."
 link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#N1030C'
-level: suggestion
+level: warning
 scope: heading
 match: $sentence
 indicators:
   - ':'
+  - '.'
 exceptions:
   - IBM
+  - IBM Quantum
+  - Qiskit
+  - Runtime
+  - Sampler
+  - Estimator
+  - Terraform
+  - Cloud
+  - (\d+)\. 

--- a/IBMQuantum/Repetition.yml
+++ b/IBMQuantum/Repetition.yml
@@ -1,0 +1,6 @@
+extends: repetition
+message: "'%s' is repeated!"
+level: error
+alpha: true
+tokens:
+  - '[^\s]+'

--- a/IBMQuantum/Terms.yml
+++ b/IBMQuantum/Terms.yml
@@ -1,7 +1,7 @@
 extends: substitution
-message: Consider using '%s' instead of '%s'
+message: Use '%s' rather than '%s'
 link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#wordlist'
-level: error
+level: warning
 ignorecase: true
 action:
   name: replace
@@ -110,7 +110,6 @@ swap:
   irrecoverable: unrecoverable
   jar: compress|archive
   keep in mind: remember
-  key: type|press
   laptop: notebook
   launch: start|open
   left-hand: left

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -4,8 +4,8 @@ Feature: Rules
         When I test "Terms"
         Then the output should contain exactly:
         """
-        test.md:3:13:IBMQuantum.Terms:Consider using 'lower left' or 'lower-left' instead of 'bottom-left'
-        test.md:5:11:IBMQuantum.Terms:Consider using 'several' instead of 'a number of'
+        test.md:3:13:IBMQuantum.Terms:Use 'lower left' or 'lower-left' rather than 'bottom-left'
+        test.md:5:11:IBMQuantum.Terms:Use 'several' rather than 'a number of'
         """
 
     Scenario: Use of punctuation


### PR DESCRIPTION
- Reduce false positives in `Headings`:
  - Will now ignore numbers in heads (such as "1. Create an account")
  - Added some proper nouns to ignore
- Reduced severity of `Terms`, and used "rather than" as per its suggestion
- Added a useful `Repetition` rule to catch things like "the the"
