### PR TITLE
Add rule for 'however'

### DIFF
--- a/IBMQuantum/However.yml
+++ b/IBMQuantum/However.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: Double check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
+level: suggestion
+code: false
+ignorecase: true
+raw:
+    - ([^;,] however|however[^,])

--- a/IBMQuantum/However.yml
+++ b/IBMQuantum/However.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: Double check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
+message: Double-check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
 level: suggestion
 code: false
 ignorecase: true

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -8,6 +8,8 @@ Feature: Rules
         test.md:5:11:IBMQuantum.Terms:Use 'several' rather than 'a number of'
         test.md:7:9:IBMQuantum.Terms:Use 'complete' or 'perform' rather than 'do'
         test.md:11:10:IBMQuantum.Spelling:Unknown word 'algorihm'; fix or add to dictionary.
+        test.md:17:29:IBMQuantum.However:Double check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
+        test.md:21:16:IBMQuantum.However:Double check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
         """
 
     Scenario: Use of punctuation

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -8,7 +8,7 @@ Feature: Rules
         test.md:5:11:IBMQuantum.Terms:Use 'several' rather than 'a number of'
         test.md:7:9:IBMQuantum.Terms:Use 'complete' or 'perform' rather than 'do'
         test.md:11:10:IBMQuantum.Spelling:Unknown word 'algorihm'; fix or add to dictionary.
-        test.md:17:29:IBMQuantum.However:Double check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
+        test.md:17:29:IBMQuantum.However:Double-check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
         test.md:21:16:IBMQuantum.However:Double check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
         """
 

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -9,7 +9,7 @@ Feature: Rules
         test.md:7:9:IBMQuantum.Terms:Use 'complete' or 'perform' rather than 'do'
         test.md:11:10:IBMQuantum.Spelling:Unknown word 'algorihm'; fix or add to dictionary.
         test.md:17:29:IBMQuantum.However:Double-check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
-        test.md:21:16:IBMQuantum.However:Double check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
+        test.md:21:16:IBMQuantum.However:Double-check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
         """
 
     Scenario: Use of punctuation

--- a/fixtures/Terms/.vale.ini
+++ b/fixtures/Terms/.vale.ini
@@ -5,3 +5,4 @@ MinAlertLevel = suggestion
 [*.md]
 IBMQuantum.Spelling = YES
 IBMQuantum.Terms = YES
+IBMQuantum.However = YES

--- a/fixtures/Terms/test.md
+++ b/fixtures/Terms/test.md
@@ -11,3 +11,11 @@ Make sure you do not transpile the circuit.
 Grover's algorihm is a type of search algorithm.
 
 You must transpile the circuit.
+
+We wished to enforce fancy punctuation; however, we were thwarted.
+
+This sentence is incorrect, however it is a common mistake.
+
+Our rules should not, however, match this sentence.
+
+This sentence is however, bad.


### PR DESCRIPTION
Adds a rule to match punctuation around "however" that's _probably_ wrong (resolves #10).

These sentences pass:

> We wished to enforce fancy punctuation; however, we were thwarted.
> This will not, however, match this sentece.

but these will trigger a suggestion:

> This sentence is incorrect, however it is a common mistake.
> This sentence is however, bad.

```
Double check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
```
