### PR TITLE
Add typos rule

### DIFF
--- a/IBMQuantum/CommonTypos.yml
+++ b/IBMQuantum/CommonTypos.yml
@@ -1,0 +1,11 @@
+# For words that are probably typos (in quantum computing), but aren't caught
+# by the spell check
+extends: substitution
+message: "Did you mean '%s' instead of '%s'?"
+ignorecase: true
+level: warning
+action:
+  name: replace
+swap:
+  Shore: Shor
+  Grove: Grover

--- a/IBMQuantum/CommonTypos.yml
+++ b/IBMQuantum/CommonTypos.yml
@@ -9,3 +9,4 @@ action:
 swap:
   Shore: Shor
   Grove: Grover
+  open source: open-source


### PR DESCRIPTION
This rule checks for some typos I've come across that aren't caught by the spellchecker as they're valid words, just probably not the words the writer meant (in the context of quantum computing).

- Shore
- Grove
- open source

we can add to this as we come across more.
