### PR TITLE
Remove SentenceLength rule

### DIFF
--- a/IBMQuantum/SentenceLength.yml
+++ b/IBMQuantum/SentenceLength.yml
@@ -1,8 +1,0 @@
-extends: occurrence
-message: "Try to keep sentences less than 25 words."
-link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#N106FB'
-scope: sentence
-level: suggestion
-max: 25
-limit: 1
-token: \b(\w+)\b

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -41,10 +41,3 @@ Feature: Rules
         test.md:13:21:IBMQuantum.Definitions:Define acronyms and abbreviations (such as 'MDBs') on first occurrence if they're likely to be unfamiliar.
         test.md:19:224:IBMQuantum.Definitions:Define acronyms and abbreviations (such as 'DAFB') on first occurrence if they're likely to be unfamiliar.
         """
-
-    Scenario: Content Structure
-        When I test "Structure"
-        Then the output should contain exactly:
-        """
-        test.md:5:1:IBMQuantum.SentenceLength:Try to keep sentences less than 25 words.
-        """

--- a/fixtures/Structure/.vale.ini
+++ b/fixtures/Structure/.vale.ini
@@ -1,6 +1,0 @@
-StylesPath = ../../
-
-MinAlertLevel = suggestion
-
-[*.md]
-IBMQuantum.SentenceLength = YES

--- a/fixtures/Structure/test.md
+++ b/fixtures/Structure/test.md
@@ -1,5 +1,0 @@
-# Structure
-
-Keep sentences short, 25 words or fewer. Emphasize important points with the occasional short sentence (fewer than 10 words).
-
-If your docs are aimed at helping `people` code, then probably that "previous developer experience" is a good way to go, preferably with details on the specific languages/environments they'll be writing about.


### PR DESCRIPTION
Removes `IBMQuantum.SentenceLength` as it's noisy and unrealistic to enforce. Resolves #17.
