### PR TITLE
Add plain language rule

### DIFF
--- a/IBMQuantum/PlainLanguage.yml
+++ b/IBMQuantum/PlainLanguage.yml
@@ -1,0 +1,245 @@
+extends: substitution
+message: Use '%s' rather than '%s'
+link: 'https://www.plainlanguage.gov/guidelines/words/use-simple-words-phrases/'
+level: warning
+ignorecase: true
+action:
+  name: replace
+# swap maps tokens in form of bad: good
+swap:
+  and/or: a or b|a, b, or both
+  accompany: go with
+  accomplish: carry out|do
+  accorded: given
+  accordingly: so
+  accrue: add|gain
+  accurate: correct|exact|right
+  additional: added|more|other
+  address: discuss
+  addressees: you
+  addressees are requested: (omit)|please
+  adjacent to: next to
+  advantageous: helpful
+  adversely impact on: hurt|set back
+  advise: recommend|tell
+  afford(?s) an opportunity: allow|let
+  aircraft: plane
+  allocate: divide
+  anticipate: expect
+  a number of: some
+  apparent: clear|plain
+  appreciable: many
+  appropriate: (omit)|proper|right
+  approximate: about
+  arrive onboard: arrive
+  as a means of: to
+  ascertain: find out|learn
+  as prescribed by: in|under
+  assist: aid|help
+  assistance: aid|help
+  attain: meet
+  attempt: try
+  at the present time: at present|now
+  be advised: (omit)
+  benefit: help
+  by means of: by|with
+  capability: ability
+  caveat: warning
+  close proximity: near
+  combined: joint
+  commence: begin|start
+  comply with: follow
+  component: part
+  comprise: form|include|make up
+  concerning: about|on
+  consequently: so
+  consolidate: combine|join|merge
+  constitutes: is|forms|makes up
+  contains: has
+  convene: meet
+  currently: (omit)|now
+  deem: believe|consider|think
+  delete: cut|drop
+  demonstrate: prove|show
+  depart: leave
+  designate: appoint|choose|name
+  desire: want|wish
+  determine: decide|figure|find
+  disclose: show
+  discontinue: drop|stop
+  disseminate: give|issue|pass|send
+  due to the fact that: due to|since
+  during the period: during
+  effect modifications: make changes
+  elect: choose|pick
+  eliminate: cut|drop|end
+  employ: use
+  encounter: meet
+  endeavor: try
+  ensure: make sure
+  enumerate: count
+  equipments: equipment
+  equitable: fair
+  establish: set up|prove|show
+  evidenced: showed
+  evident: clear
+  exhibit: show
+  expedite: hasten|speed up
+  expeditious: fast|quick
+  expend: spend
+  expertise: ability
+  expiration: end
+  facilitate: ease|help
+  failed to: didn’t
+  feasible: can be done|workable
+  females: women
+  finalize: complete|finish
+  for a period of: for
+  for example,______etc.: for example|such as
+  forfeit: give up|lose
+  forward: send
+  frequently: often
+  function: act|role|work
+  furnish: give|send
+  has a requirement for: needs
+  herein: here
+  heretofore: until now
+  herewith: below|here
+  however: but
+  identical: same
+  identify: find|name|show
+  immediately: at once
+  impacted: affected|changed
+  implement: carry out|start
+  in accordance with: by|following|per|under
+  in addition: also|besides|too
+  in an effort to: to
+  inasmuch as: since
+  in a timely manner: on time|promptly
+  inception: start
+  incumbent upon: must
+  indicate: show|write down
+  indication: sign
+  initial: first
+  initiate: start
+  in lieu of: instead
+  in order that: for|so
+  in order to: to
+  in regard to: about|concerning|on
+  in relation to: about|with|to
+  inter alia: (omit)
+  interface: meet|work with
+  interpose no objection: don’t object
+  in the amount: for
+  in the event: if
+  in the near future: shortly|soon
+  in the process of: (omit)
+  in view of: since
+  in view of the above: so
+  is applicable to: applies to
+  is authorized to: may
+  is in consonance with: agrees with|follows
+  is responsible for: (omit) handles
+  it appears: seems
+  it is: (omit)
+  it is essential: must|need to
+  it is requested: please|we request|I request
+  liaison: discussion
+  limited number: limits
+  magnitude: size
+  maintain: keep|support
+  maximum: greatest|largest|most
+  methodology: method
+  minimize: decrease|method
+  minimum: least|smallest
+  modify: change
+  monitor: check|watch
+  necessitate: cause|need
+  notify: let know|tell
+  not later than: by|before
+  notwithstanding: inspite of|still
+  numerous: many
+  objective: aim|goal
+  obligate: bind|compel
+  observe: see
+  on a regular basis: (omit)
+  operate: run|use|work
+  optimum: best|greatest|most
+  option: choice|way
+  parameters: limits
+  participate: take part
+  perform: do
+  permit: let
+  pertaining to: about|of|on
+  portion: part
+  possess: have|own
+  practicable: practical
+  preclude: prevent
+  previous: earlier
+  previously: before
+  prioritize: rank
+  prior to: before
+  proceed: do|go ahead|try
+  procure: (omit)
+  proficiency: skill
+  promulgate: issue|publish
+  provide: give|offer|say
+  provided that: if
+  provides guidance for: guides
+  purchase: buy
+  pursuant to: by|following|per|under
+  reflect: say|show
+  regarding: about|of|on
+  relative to: about|on
+  relocate: move
+  remain: stay
+  remain: stay
+  remainder: rest
+  remuneration: pay|payment
+  render: give|make
+  represents: is
+  request: ask
+  require: must|need
+  requirement: need
+  reside: live
+  retain: keep
+  said|some|such: the|this|that
+  selection: choice
+  set forth in: in
+  similar to: like
+  solicit: ask for|request
+  state-of-the-art: latest
+  subject: the|this|your
+  submit: give|send
+  subsequent: later|next
+  subsequently: after|later|then
+  substantial: large|much
+  successfully complete: complete|pass
+  sufficient: enough
+  take action to: (omit)
+  terminate: end|stop
+  the month of: (omit)
+  there are: (omit)
+  therefore: so
+  therein: there
+  there is: (omit)
+  thereof: its|their
+  the undersigned: I
+  the use of: (omit)
+  this activity|command: us|we
+  timely: prompt
+  time period: (either one)
+  transmit: send
+  type: (omit)
+  under the provisions of: under
+  until such time as: until
+  utilize|utilization: use
+  validate: confirm
+  viable: practical|workable
+  vice: instead of|versus
+  warrant: call for|permit
+  whereas: because|since
+  with reference to: about
+  with the exception of: except for
+  witnessed: saw
+  your office: you

--- a/IBMQuantum/Terms.yml
+++ b/IBMQuantum/Terms.yml
@@ -21,11 +21,9 @@ swap:
   below: following
   above: previous
   top: start|beginning|first
-  a number of: several
   abort: cancel|stop
   administrate: administer
   all caps: uppercase
-  and/or: a or b|a, b, or both
   as long as: if|provided that
   as per: according to|as|as in
   back-level: earlier|previous|not at the latest level
@@ -43,7 +41,6 @@ swap:
   comes with: includes
   componentization: component-based development|component model|component architecture|shared components
   componentize: develop components
-  comprised of: consist of
   connect with: connect to
   context menu: menu|pop-up menu
   contextual help: help|context-sensitive help
@@ -59,7 +56,6 @@ swap:
   demo: demonstration
   depress: press|type
   deregister: unregister
-  desire: want|required
   destroy: delete from the database
   dismount: demount|unmount|remove
   downgrade: upgrade|fallback|fall back|rollback|roll back
@@ -89,15 +85,12 @@ swap:
   IBM's: IBM's|IBM's AIX
   ifix: interim fix
   iFix: interim fix
-  in order to: to
   in other words: for example|that is
   in spite of: regardless of|despite
-  in the event: in case|if|when
   inactivate: deactivate
   information on: information about
   information technology: IT
   instead of: rather than
-  insure: ensure
   Internet address: IP address|URL|Internet email address|web address
   irrecoverable: unrecoverable
   jar: compress|archive
@@ -133,7 +126,6 @@ swap:
   preload: preinstall|preinstalled
   preloaded: preinstall|preinstalled
   prepend: add a prefix to
-  prior to: before
   recommend: suggest
   retry: retry|try again
   right double-click: double right-click
@@ -155,7 +147,6 @@ swap:
   switch on: power on|turn on|power off|turn off
   tar: compress|archive
   tarball: tar file
-  terminate: end|stop
   thru: through
   thumbstick: USB flash drive
   thus: therefore


### PR DESCRIPTION
IBM's [UI writing guide](https://pages.github.ibm.com/Design/ux-writing-course/terminology/5#non-ibm-resources) recommends the US government's [plain language guide](https://www.plainlanguage.gov/guidelines/words/use-simple-words-phrases/). This is just a set of substitutions which are easy to match, so I've added them as a rule.

We should go through an remove any that don't apply, or that are likely to cause lots of false positives. There's also some overlap with the existing `IBMQuantum.Terms` rule; I've removed the overlapping words from that rule.
