### PR TITLE
Implicit punctuation rules

### DIFF
--- a/IBMQuantum/DisplayEquationPunctuation.yml
+++ b/IBMQuantum/DisplayEquationPunctuation.yml
@@ -1,7 +1,0 @@
-extends: existence
-message: "Remove commas or periods after display equations."
-link: "https://github.com/IBM/ibm-quantum-style-guide/issues/22"
-level: warning
-scope: raw
-raw:
-  - '(\\\]|\$\$)(\s*?)[,.]'

--- a/IBMQuantum/DisplayEquationPunctuation.yml
+++ b/IBMQuantum/DisplayEquationPunctuation.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Remove commas or periods after display equations."
+link: "https://github.com/IBM/ibm-quantum-style-guide/issues/22"
+level: warning
+scope: raw
+raw:
+  - '(\\\]|\$\$)(\s*?)[,.]'

--- a/IBMQuantum/ListPunctuation.yml
+++ b/IBMQuantum/ListPunctuation.yml
@@ -1,7 +1,7 @@
 extends: existence
-message: "Remove punctuation from lists (…%s)"
+message: "Remove commas at end of list items (…%s)"
 link: "https://github.com/IBM/ibm-quantum-style-guide/issues/22"
 level: warning
 scope: list
 raw:
-  - '(\w*?)[,.](\s*?)$'
+  - '(\w*?),(\s*?)$'

--- a/IBMQuantum/ListPunctuation.yml
+++ b/IBMQuantum/ListPunctuation.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Remove punctuation from lists (…%s)"
+link: "https://github.com/IBM/ibm-quantum-style-guide/issues/22"
+level: warning
+scope: list
+raw:
+  - '(\w*?)[,.](\s*?)$'

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -24,6 +24,8 @@ Feature: Rules
         test.md:23:14:IBMQuantum.DashSpacing:Add spaces around the dash in 'a—w'.
         test.md:31:22:IBMQuantum.ListPunctuation:Remove punctuation from lists (…comma,)
         test.md:32:24:IBMQuantum.ListPunctuation:Remove punctuation from lists (…period.)
+        test.md:37:8:IBMQuantum.DisplayEquationPunctuation:Remove commas or periods after display equations.
+        test.md:41:8:IBMQuantum.DisplayEquationPunctuation:Remove commas or periods after display equations.
         """
 
     Scenario: Use of Latin abbreviations

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -22,6 +22,8 @@ Feature: Rules
         test.md:11:1:IBMQuantum.Abbreviations:Do not use periods in all-uppercase abbreviations such as 'S.W.A.T.'.
         test.md:17:1:IBMQuantum.OxfordComma:Use the Oxford comma in 'It comes in red, blue and'.
         test.md:23:14:IBMQuantum.DashSpacing:Add spaces around the dash in 'a—w'.
+        test.md:31:22:IBMQuantum.ListPunctuation:Remove punctuation from lists (…comma,)
+        test.md:32:24:IBMQuantum.ListPunctuation:Remove punctuation from lists (…period.)
         """
 
     Scenario: Use of Latin abbreviations

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -23,8 +23,6 @@ Feature: Rules
         test.md:17:1:IBMQuantum.OxfordComma:Use the Oxford comma in 'It comes in red, blue and'.
         test.md:23:14:IBMQuantum.DashSpacing:Add spaces around the dash in 'a—w'.
         test.md:31:24:IBMQuantum.ListPunctuation:Remove commas at end of list items (…comma,)
-        test.md:37:8:IBMQuantum.DisplayEquationPunctuation:Remove commas or periods after display equations.
-        test.md:41:8:IBMQuantum.DisplayEquationPunctuation:Remove commas or periods after display equations.
         """
 
     Scenario: Use of Latin abbreviations

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -22,8 +22,7 @@ Feature: Rules
         test.md:11:1:IBMQuantum.Abbreviations:Do not use periods in all-uppercase abbreviations such as 'S.W.A.T.'.
         test.md:17:1:IBMQuantum.OxfordComma:Use the Oxford comma in 'It comes in red, blue and'.
         test.md:23:14:IBMQuantum.DashSpacing:Add spaces around the dash in 'a—w'.
-        test.md:31:22:IBMQuantum.ListPunctuation:Remove punctuation from lists (…comma,)
-        test.md:32:24:IBMQuantum.ListPunctuation:Remove punctuation from lists (…period.)
+        test.md:31:24:IBMQuantum.ListPunctuation:Remove commas at end of list items (…comma,)
         test.md:37:8:IBMQuantum.DisplayEquationPunctuation:Remove commas or periods after display equations.
         test.md:41:8:IBMQuantum.DisplayEquationPunctuation:Remove commas or periods after display equations.
         """

--- a/fixtures/Punctuation/.vale.ini
+++ b/fixtures/Punctuation/.vale.ini
@@ -7,3 +7,4 @@ IBMQuantum.Abbreviations = YES
 IBMQuantum.OxfordComma = YES
 IBMQuantum.DashSpacing = YES
 IBMQuantum.ListPunctuation = YES
+IBMQuantum.DisplayEquationPunctuation = YES

--- a/fixtures/Punctuation/.vale.ini
+++ b/fixtures/Punctuation/.vale.ini
@@ -6,3 +6,4 @@ MinAlertLevel = suggestion
 IBMQuantum.Abbreviations = YES
 IBMQuantum.OxfordComma = YES
 IBMQuantum.DashSpacing = YES
+IBMQuantum.ListPunctuation = YES

--- a/fixtures/Punctuation/.vale.ini
+++ b/fixtures/Punctuation/.vale.ini
@@ -7,4 +7,3 @@ IBMQuantum.Abbreviations = YES
 IBMQuantum.OxfordComma = YES
 IBMQuantum.DashSpacing = YES
 IBMQuantum.ListPunctuation = YES
-IBMQuantum.DisplayEquationPunctuation = YES

--- a/fixtures/Punctuation/test.md
+++ b/fixtures/Punctuation/test.md
@@ -28,8 +28,8 @@ Here's an idea — we should use spaces around dashes.
 
 The following list breaks the rules as it
 
-- ends a bullet with comma,
-* ends a bullet with a period.
+- ends a bullet with a comma,
+
 
 
 The following display equation ends with some punctuation, which looks weird

--- a/fixtures/Punctuation/test.md
+++ b/fixtures/Punctuation/test.md
@@ -23,3 +23,10 @@ Use the mdash (`<mdash/>`) to signal a brief and relevant detour in thought. Kee
 Here's an idea—we should use spaces around dashes.
 
 Here's an idea — we should use spaces around dashes.
+
+## Implicit punctuation
+
+The following list breaks the rules as it
+
+- ends a bullet with comma,
+* ends a bullet with a period.

--- a/fixtures/Punctuation/test.md
+++ b/fixtures/Punctuation/test.md
@@ -30,3 +30,13 @@ The following list breaks the rules as it
 
 - ends a bullet with comma,
 * ends a bullet with a period.
+
+
+The following display equation ends with some punctuation, which looks weird
+
+$$ x^2 $$,
+
+as does the following equation
+
+\[ x^4 \]
+.

--- a/fixtures/Punctuation/test.md
+++ b/fixtures/Punctuation/test.md
@@ -29,14 +29,3 @@ Here's an idea — we should use spaces around dashes.
 The following list breaks the rules as it
 
 - ends a bullet with a comma,
-
-
-
-The following display equation ends with some punctuation, which looks weird
-
-$$ x^2 $$,
-
-as does the following equation
-
-\[ x^4 \]
-.


### PR DESCRIPTION
This PR adds a couple of rules:

1. **ListPunctuation**

   This rule matches any list items ending wth commas or periods (see https://github.com/IBM/ibm-quantum-style-guide/issues/22#issuecomment-1470318892)

   Example:

   > - This list item ends in a period.

   ```
   IBMQuantum.ListPunctuation:Remove punctuation from lists (…period.)
   ```


2. ~~**DisplayEquationPunctuation**~~

   ~~This rule matches any commas or periods immediately after display equations. I don't think there was a consensus on this rule, so let me know if I should remove it.~~

   Removing until we reach a consensus.