### PR TITLE
Add "cringe words" rule

### DIFF
--- a/IBMQuantum/CringeWords.yml
+++ b/IBMQuantum/CringeWords.yml
@@ -1,0 +1,20 @@
+extends: existence
+message: "Don't use '%s'"
+link: 'https://github.com/IBM/ibm-quantum-style-guide/issues/22'
+ignorecase: true
+scope: sentence
+level: warning
+tokens:
+  - allows you to
+  - easy
+  - enable
+  - enables
+  - end user
+  - end users
+  - in the future
+  - that's all there is to it
+  - very
+  - we encourage you
+  - we understand that
+  - you can see
+  - you can think of this

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -12,6 +12,10 @@ Feature: Rules
         test.md:19:29:IBMQuantum.However:Double-check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
         test.md:23:16:IBMQuantum.However:Double-check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
         test.md:25:1:IBMQuantum.Politeness:Don't use 'Please'
+        test.md:27:1:IBMQuantum.CringeWords:Don't use 'We understand that'
+        test.md:27:36:IBMQuantum.Terms:Use 'use' rather than 'utilize'
+        test.md:27:75:IBMQuantum.CringeWords:Don't use 'end users'
+        test.md:27:90:IBMQuantum.CringeWords:Don't use 'we encourage you'
         """
 
     Scenario: Use of punctuation

--- a/fixtures/Terms/.vale.ini
+++ b/fixtures/Terms/.vale.ini
@@ -5,5 +5,6 @@ MinAlertLevel = suggestion
 [*.md]
 IBMQuantum.Spelling = YES
 IBMQuantum.Terms = YES
+IBMQuantum.CringeWords = YES
 IBMQuantum.Politeness = YES
 IBMQuantum.However = YES

--- a/fixtures/Terms/test.md
+++ b/fixtures/Terms/test.md
@@ -23,3 +23,5 @@ Our rules should not, however, match this sentence.
 This sentence is however, bad.
 
 Please do not be too polite in your technical writing.
+
+We understand that you may want to utilize these phrases when writing for end users, but we encourage you not to.


### PR DESCRIPTION
Matches:
  - allows you to
  - easy
  - enable
  - enables
  - end user
  - end users
  - in the future
  - that's all there is to it
  - very
  - we encourage you
  - we understand that
  - you can see
  - you can think of this

Will give a warning, such as:
```
IBMQuantum.CringeWords:Don't use 'we encourage you'
```

I didn't include 'utilize' as it's already covered in `IBMQuantum.Terms`.