### PR TITLE
Add Links rule

### DIFF
--- a/IBMQuantum/Links.yml
+++ b/IBMQuantum/Links.yml
@@ -1,0 +1,16 @@
+extends: existence
+message: Link names should make sense without context; change "%s" to something more descriptive.
+level: suggestion
+code: false
+scope: link
+ignorecase: true
+tokens:
+    - click here
+    - here
+    - link
+    - more
+    - more information
+    - page
+    - read more
+    - this link
+    - this page

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -12,6 +12,7 @@ Feature: Rules
         test.md:19:29:IBMQuantum.However:Double-check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
         test.md:23:16:IBMQuantum.However:Double-check your punctuation around 'however' (see github.com/IBM/ibm-quantum-style-guide/issues/10 for more information).
         test.md:25:1:IBMQuantum.Politeness:Don't use 'Please'
+        test.md:27:12:IBMQuantum.Links:Link names should make sense without context; change "link" to something more descriptive.
         """
 
     Scenario: Use of punctuation

--- a/fixtures/Terms/.vale.ini
+++ b/fixtures/Terms/.vale.ini
@@ -7,3 +7,4 @@ IBMQuantum.Spelling = YES
 IBMQuantum.Terms = YES
 IBMQuantum.Politeness = YES
 IBMQuantum.However = YES
+IBMQuantum.Links = YES

--- a/fixtures/Terms/test.md
+++ b/fixtures/Terms/test.md
@@ -23,3 +23,7 @@ Our rules should not, however, match this sentence.
 This sentence is however, bad.
 
 Please do not be too polite in your technical writing.
+
+This is a [link](www.ibm.com) to IBM's site.
+
+Check out this link to the [IBM website](www.ibm.com).


### PR DESCRIPTION
Inspired by https://github.com/IBM/ibm-quantum-style-guide/issues/22#issuecomment-1470318892, this rule matches links with the following text:

- click here
- here
- link
- more
- more information
- page
- read more
- this link
- this page

feel free to add any more phrases. For more context see [Yale's advice on links and accessibility](https://usability.yale.edu/web-accessibility/articles/links).
