### PR TITLE
Fix latin rule

### DIFF
--- a/IBMQuantum/Latin.yml
+++ b/IBMQuantum/Latin.yml
@@ -11,5 +11,5 @@ swap:
   '\b(?:ie|i\.e\.)[\s,]': that is
   '\betc\.': and so on
   '\bvs\.': compared to
-  via: through
-  versus: compared to
+  '\bvia\b': through
+  '\bversus\b': compared to

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -33,7 +33,6 @@ Feature: Rules
         When I test "Latin"
         Then the output should contain exactly:
         """
-        test.md:1:21:IBMQuantum.Latin:Use 'through' instead of 'via'.
         test.md:3:10:IBMQuantum.Latin:Use 'and so on' instead of 'etc.'.
         test.md:5:31:IBMQuantum.Latin:Use 'that is' instead of 'i.e.,'.
         test.md:7:6:IBMQuantum.Latin:Use 'compared to' instead of 'vs.'.


### PR DESCRIPTION
Quick fix: rule was matching `via` in the middle of words.
